### PR TITLE
Keep existing query parameters

### DIFF
--- a/Sources/URLSessionDecodable/Parameters.swift
+++ b/Sources/URLSessionDecodable/Parameters.swift
@@ -65,7 +65,7 @@ public struct URLParametersEncoder: ParametersEncoding {
         }
 
         var request = urlRequest
-        var query: [URLQueryItem] = []
+        var query: [URLQueryItem] = components.queryItems ?? []
         parameters.forEach { name, value in
             query.append(URLQueryItem(name: name, value: value))
         }

--- a/Tests/URLSessionDecodableTests/ParametersTests.swift
+++ b/Tests/URLSessionDecodableTests/ParametersTests.swift
@@ -30,10 +30,8 @@ final class ParametersTests: XCTestCase {
             "param2": "abc",
             "param3": "foo"
         ]
-        let urlParameters = queryItems.reduce([String:String]()) { dict, param in
-            var dict = dict
-            dict[param.name] = param.value
-            return dict
+        let urlParameters = queryItems.reduce(into: [:]) { dictionary, param in
+            dictionary[param.name] = param.value
         }
         XCTAssertEqual(expectedParameters, urlParameters)
         XCTAssertEqual(queryItems.count, 4) // params are appended currently

--- a/Tests/URLSessionDecodableTests/ParametersTests.swift
+++ b/Tests/URLSessionDecodableTests/ParametersTests.swift
@@ -36,6 +36,7 @@ final class ParametersTests: XCTestCase {
             return dict
         }
         XCTAssertEqual(expectedParameters, urlParameters)
+        XCTAssertEqual(queryItems.count, 4) // params are appended currently
     }
 
     func testURLEncodingWithEmptyParameters() {

--- a/Tests/URLSessionDecodableTests/ParametersTests.swift
+++ b/Tests/URLSessionDecodableTests/ParametersTests.swift
@@ -16,6 +16,28 @@ final class ParametersTests: XCTestCase {
         }
     }
 
+    func testURLEncodingWithExistingParameters() {
+        let params = [
+            "param1": "1",
+            "param2": "abc"
+        ]
+        let request = URLRequest(url: URL(string: "www.viacom.com/test?param1=0&param3=foo")!)
+        let encodedUrl = URLParametersEncoder(parameters: params).encode(into: request).url!
+        let queryItems = URLComponents(url: encodedUrl, resolvingAgainstBaseURL: false)!.queryItems!
+
+        let expectedParameters: [String: String] = [
+            "param1": "1",
+            "param2": "abc",
+            "param3": "foo"
+        ]
+        let urlParameters = queryItems.reduce([String:String]()) { dict, param in
+            var dict = dict
+            dict[param.name] = param.value
+            return dict
+        }
+        XCTAssertEqual(expectedParameters, urlParameters)
+    }
+
     func testURLEncodingWithEmptyParameters() {
         let params = [String: String]()
         let request = URLRequest(url: URL(string: "www.viacom.com/test")!)


### PR DESCRIPTION
In case url already had query parameters encoded, adding new ones would drop them.
Since the url can be provided from a backend, it can already contain predefined parameters, and we shouldn't drop them (can be appended under the same key)
If a url is created 'by hand', in app, we have control over the parameters.