### PR TITLE
Enable Strict Concurrency mode

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,13 +10,11 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on:  macOS-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Select Xcode 14.2
-        run: sudo xcode-select -s /Applications/Xcode_14.2.app
-      - name: Run swiftlint
-        run: swiftlint
+      - name: Select Xcode 15.4
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Run tests
         run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -1,13 +1,13 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.10
 
 import PackageDescription
 
 let package = Package(
     name: "URLSessionDecodable",
     platforms: [
-        .macOS(.v10_13),
-        .iOS(.v11),
-        .tvOS(.v11),
+        .macOS(.v13),
+        .iOS(.v12),
+        .tvOS(.v12),
         .watchOS(.v4)
     ],
     products: [
@@ -15,16 +15,21 @@ let package = Package(
             name: "URLSessionDecodable",
             targets: ["URLSessionDecodable"])
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
         .target(
             name: "URLSessionDecodable",
-            dependencies: []),
+            dependencies: [],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
         .testTarget(
             name: "URLSessionDecodableTests",
-            dependencies: ["URLSessionDecodable"])
+            dependencies: ["URLSessionDecodable"],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
+        ),
     ]
 )

--- a/Sources/URLSessionDecodable/URLSessionDecodable.swift
+++ b/Sources/URLSessionDecodable/URLSessionDecodable.swift
@@ -60,7 +60,7 @@ extension URLSession {
         method: HTTPMethod,
         parameters: ParametersEncoding?,
         headers: HTTPHeaders?,
-        decoder: @autoclosure @escaping @Sendable () -> DataDecoder
+        decoder: @autoclosure @Sendable () -> DataDecoder
     ) async throws -> T {
         let request = self.request(with: url, method: method, parameters: parameters, headers: headers)
         let (data, response) = try await data(for: request)
@@ -76,7 +76,7 @@ extension URLSession {
     private static func handle<T: Decodable>(
         response: HTTPURLResponse,
         data: Data,
-        decoder: @autoclosure @escaping @Sendable () -> DataDecoder,
+        decoder: @autoclosure @Sendable () -> DataDecoder,
         url: URL
     ) -> Result<T, URLSessionDecodableError> {
         guard 200..<300 ~= response.statusCode else {

--- a/Sources/URLSessionDecodable/URLSessionDecodableError.swift
+++ b/Sources/URLSessionDecodable/URLSessionDecodableError.swift
@@ -9,14 +9,14 @@ public enum URLSessionDecodableError: Error {
     case nonHTTPResponse(URLResponse)
     case serverResponse(ServerResponse)
 
-    public struct Deserialization {
+    public struct Deserialization: Sendable {
         public let statusCode: Int
         public let url: URL
         public let responseBody: Data
         public let underlyingError: Error?
     }
 
-    public struct ServerResponse {
+    public struct ServerResponse: Sendable {
         public let statusCode: Int
         public let url: URL
         public let responseBody: Data


### PR DESCRIPTION
- Enable strict concurrency mode
- Bump minimal OS versions (required by swift-tools-version:5.10)
- Tweak codebase to build with strict concurrency mode without warnings