### PR TITLE
support for patch method

### DIFF
--- a/Sources/URLSessionDecodable/URLSessionDecodable.swift
+++ b/Sources/URLSessionDecodable/URLSessionDecodable.swift
@@ -10,6 +10,7 @@ public enum HTTPMethod: String {
     case get
     case post
     case put
+    case patch
 }
 
 extension URLSession {


### PR DESCRIPTION
Currently URLSessionDecodable supports 4 out of 5 HTTP methods. This PR adds support for the missing `patch` method. 